### PR TITLE
Improve description of "run_rate" field.

### DIFF
--- a/src/main/java/org/graylog/outputs/metrics/MetricsOutput.java
+++ b/src/main/java/org/graylog/outputs/metrics/MetricsOutput.java
@@ -192,7 +192,7 @@ public class MetricsOutput implements MessageOutput {
                             CK_RUN_RATE,
                             "Submission frequency (seconds)",
                             30,
-                            "How often per second will Graylog submit metrics to the endpoint. " +
+                            "The period (in seconds) at which Graylog will submit metrics to the endpoint. " +
                             "Keep this number high to not flood the metrics store.",
                             ConfigurationField.Optional.NOT_OPTIONAL,
                             NumberField.Attribute.ONLY_POSITIVE)


### PR DESCRIPTION
I think the current description of the "run_rate" field is wrong (and contradicts itself). The field does not configure how often per second metrics are reported but at which period.
